### PR TITLE
Add iOS 15 payload additions (#185)

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ APNS/2 is a go package designed for simple, flexible and fast Apple Push Notific
 - Works with go 1.7 and later
 - Supports new Apple Token Based Authentication (JWT)
 - Supports new iOS 10 features such as Collapse IDs, Subtitles and Mutable Notifications
+- Supports new iOS 15 fetaures interruptionLevel and relevanceScore
 - Supports persistent connections to APNs
 - Supports VoIP/PushKit notifications (iOS 8 and later)
 - Modular & easy to use

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -4,6 +4,25 @@ package payload
 
 import "encoding/json"
 
+// InterruptionLevel defines the value for the payload aps interruption-level
+type EInterruptionLevel string
+
+const (
+	// InterruptionLevelPassive is used to indicate that notification be delivered in a passive manner.
+	InterruptionLevelPassive EInterruptionLevel = "passive"
+
+	// InterruptionLevelActive is used to indicate the importance and delivery timing of a notification.
+	InterruptionLevelActive EInterruptionLevel = "active"
+
+	// InterruptionLevelTimeSensitive is used to indicate the importance and delivery timing of a notification.
+	InterruptionLevelTimeSensitive EInterruptionLevel = "time-sensitive"
+
+	// InterruptionLevelCritical is used to indicate the importance and delivery timing of a notification.
+	// This interruption level requires an approved entitlement from Apple.
+	// See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
+	InterruptionLevelCritical EInterruptionLevel = "critical"
+)
+
 // Payload represents a notification which holds the content that will be
 // marshalled as JSON.
 type Payload struct {
@@ -11,14 +30,16 @@ type Payload struct {
 }
 
 type aps struct {
-	Alert            interface{} `json:"alert,omitempty"`
-	Badge            interface{} `json:"badge,omitempty"`
-	Category         string      `json:"category,omitempty"`
-	ContentAvailable int         `json:"content-available,omitempty"`
-	MutableContent   int         `json:"mutable-content,omitempty"`
-	Sound            interface{} `json:"sound,omitempty"`
-	ThreadID         string      `json:"thread-id,omitempty"`
-	URLArgs          []string    `json:"url-args,omitempty"`
+	Alert             interface{}        `json:"alert,omitempty"`
+	Badge             interface{}        `json:"badge,omitempty"`
+	Category          string             `json:"category,omitempty"`
+	ContentAvailable  int                `json:"content-available,omitempty"`
+	InterruptionLevel EInterruptionLevel `json:"interruption-level,omitempty"`
+	MutableContent    int                `json:"mutable-content,omitempty"`
+	RelevanceScore    interface{}        `json:"relevance-score,omitempty"`
+	Sound             interface{}        `json:"sound,omitempty"`
+	ThreadID          string             `json:"thread-id,omitempty"`
+	URLArgs           []string           `json:"url-args,omitempty"`
 }
 
 type alert struct {
@@ -321,6 +342,39 @@ func (p *Payload) SoundName(name string) *Payload {
 // {"aps":{"sound":{"critical":1,"name":"default","volume":volume}}}
 func (p *Payload) SoundVolume(volume float32) *Payload {
 	p.aps().sound().Volume = volume
+	return p
+}
+
+// InterruptionLevel defines the value for the payload aps interruption-level
+// This is to indicate the importance and delivery timing of a notification.
+// (Using InterruptionLevelCritical requires an approved entitlement from Apple.)
+// See: https://developer.apple.com/documentation/usernotifications/unnotificationinterruptionlevel/
+//
+// {"aps":{"interruption-level":passive}}
+func (p *Payload) InterruptionLevel(interruptionLevel EInterruptionLevel) *Payload {
+	p.aps().InterruptionLevel = interruptionLevel
+	return p
+}
+
+// The relevance score, a number between 0 and 1,
+// that the system uses to sort the notifications from your app.
+// The highest score gets featured in the notification summary.
+// See https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore.
+//
+//	{"aps":{"relevance-score":0.1}}
+func (p *Payload) RelevanceScore(b float32) *Payload {
+	p.aps().RelevanceScore = b
+	return p
+}
+
+// Unsets the relevance score
+// that the system uses to sort the notifications from your app.
+// The highest score gets featured in the notification summary.
+// See https://developer.apple.com/documentation/usernotifications/unnotificationcontent/3821031-relevancescore.
+//
+//	{"aps":{"relevance-score":0.1}}
+func (p *Payload) UnsetRelevanceScore() *Payload {
+	p.aps().RelevanceScore = nil
 	return p
 }
 

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -188,8 +188,50 @@ func TestAlertSummaryArgCount(t *testing.T) {
 	assert.Equal(t, `{"aps":{"alert":{"summary-arg-count":3}}}`, string(b))
 }
 
-func TestCombined(t *testing.T) {
-	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").Custom("key", "val")
+func TestInterruptionLevelPassive(t *testing.T) {
+	payload := NewPayload().InterruptionLevel(InterruptionLevelPassive)
 	b, _ := json.Marshal(payload)
-	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"sound":"Default.caf"},"key":"val"}`, string(b))
+	assert.Equal(t, `{"aps":{"interruption-level":"passive"}}`, string(b))
+}
+
+func TestInterruptionLevelActive(t *testing.T) {
+	payload := NewPayload().InterruptionLevel(InterruptionLevelActive)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"interruption-level":"active"}}`, string(b))
+}
+
+func TestInterruptionLevelTimeSensitive(t *testing.T) {
+	payload := NewPayload().InterruptionLevel(InterruptionLevelTimeSensitive)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"interruption-level":"time-sensitive"}}`, string(b))
+}
+
+func TestInterruptionLevelCritical(t *testing.T) {
+	payload := NewPayload().InterruptionLevel(InterruptionLevelCritical)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"interruption-level":"critical"}}`, string(b))
+}
+
+func TestRelevanceScore(t *testing.T) {
+	payload := NewPayload().RelevanceScore(0.1)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"relevance-score":0.1}}`, string(b))
+}
+
+func TestRelevanceScoreZero(t *testing.T) {
+	payload := NewPayload().RelevanceScore(0)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"relevance-score":0}}`, string(b))
+}
+
+func TestUnsetRelevanceScore(t *testing.T) {
+	payload := NewPayload().RelevanceScore(0.1).UnsetRelevanceScore()
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{}}`, string(b))
+}
+
+func TestCombined(t *testing.T) {
+	payload := NewPayload().Alert("hello").Badge(1).Sound("Default.caf").InterruptionLevel(InterruptionLevelActive).RelevanceScore(0.1).Custom("key", "val")
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"alert":"hello","badge":1,"interruption-level":"active","relevance-score":0.1,"sound":"Default.caf"},"key":"val"}`, string(b))
 }


### PR DESCRIPTION
{review: Merges the ios 15 changes from the upstream into our master branch so that I can continue to make modifications to our fork}

* Add iOS 15 payload additions

- Add interruption-level to payload
 interruption-level options:
    - passive
    - active (default if none is passed to apns)
    - time-sensitive
    - critical (requires Apple entitlement)

- Add relevance-score to payload
relevance-score is a number between 0 and 1
The highest score gets featured in the notification summary.

* Update readme re iOS 15 features

* Fix documentation typo

Note that at the time of writing [Apple docs](https://developer.apple.com/documentation/usernotifications/setting_up_a_remote_notification_server/generating_a_remote_notification#2943360) have a typo, showing `time-senstive` as opposed to `time-sensitive`.

Testing has shown that the correct spelling `time-sensitive` does indeed work.

* Update builder.go

Alphabetically order keys in struct as per @Singwai suggestion.

* Allow relevance-score to be set to zero.

* Updated to single InterruptionLevel function

Co-authored-by: Chris Haines <chris.haines@braze.com>