### PR TITLE
[CH-5411] Add support for Attributes/AttributesType for push-to-start live activities

### DIFF
--- a/payload/builder.go
+++ b/payload/builder.go
@@ -156,7 +156,7 @@ func (p *Payload) SetAttributesType(attributesType string) *Payload {
 // SetAttributes sets the aps attributes field on the payload.
 // This is used for push-to-start live activities
 //
-//	{"aps":{"attributes-type": attributesType }}`
+//	{"aps":{"attributes": attributes }}`
 func (p *Payload) SetAttributes(attributes map[string]interface{}) *Payload {
 	p.aps().Attributes = attributes
 	return p

--- a/payload/builder.go
+++ b/payload/builder.go
@@ -56,6 +56,8 @@ type aps struct {
 	StaleDate         int64                  `json:"stale-date,omitempty"`
 	Event             ELiveActivityEvent     `json:"event,omitempty"`
 	Timestamp         int64                  `json:"timestamp,omitempty"`
+	AttributesType    string                 `json:"attributes-type,omitempty"`
+	Attributes        map[string]interface{} `json:"attributes,omitempty"`
 }
 
 type alert struct {
@@ -139,6 +141,24 @@ func (p *Payload) SetEvent(event ELiveActivityEvent) *Payload {
 //	{"aps":{"timestamp": Timestamp }}`
 func (p *Payload) SetTimestamp(timestamp int64) *Payload {
 	p.aps().Timestamp = timestamp
+	return p
+}
+
+// SetAttributesType sets the aps attributes-type field on the payload.
+// This is used for push-to-start live activities
+//
+//	{"aps":{"attributes-type": attributesType }}`
+func (p *Payload) SetAttributesType(attributesType string) *Payload {
+	p.aps().AttributesType = attributesType
+	return p
+}
+
+// SetAttributes sets the aps attributes field on the payload.
+// This is used for push-to-start live activities
+//
+//	{"aps":{"attributes-type": attributesType }}`
+func (p *Payload) SetAttributes(attributes map[string]interface{}) *Payload {
+	p.aps().Attributes = attributes
 	return p
 }
 

--- a/payload/builder_test.go
+++ b/payload/builder_test.go
@@ -186,6 +186,27 @@ func TestTimestamp(t *testing.T) {
 	assert.Equal(t, `{"aps":{"timestamp":1674821640}}`, string(b))
 }
 
+func TestAttributesType(t *testing.T) {
+	attributesType := "AdventureAttributes"
+	payload := NewPayload().SetAttributesType(attributesType)
+	b, _ := json.Marshal(payload)
+	assert.Equal(t, `{"aps":{"attributes-type":"AdventureAttributes"}}`, string(b))
+}
+
+func TestAttributes(t *testing.T) {
+	attributes := map[string]interface{}{
+		"currentHealthLevel": 100,
+		"eventDescription":   "Adventure has begun!",
+	}
+	payload := NewPayload().SetAttributes(attributes)
+	b, _ := json.Marshal(payload)
+	assert.Equal(
+		t,
+		`{"aps":{"attributes":{"currentHealthLevel":100,"eventDescription":"Adventure has begun!"}}}`,
+		string(b),
+	)
+}
+
 func TestMdm(t *testing.T) {
 	payload := NewPayload().Mdm("996ac527-9993-4a0a-8528-60b2b3c2f52b")
 	b, _ := json.Marshal(payload)


### PR DESCRIPTION
As per https://developer.apple.com/documentation/activitykit/starting-and-updating-live-activities-with-activitykit-push-notifications#Construct-the-payload-that-starts-a-Live-Activity