### PR TITLE
[CH-5425] Add temporary logging for apns request

### DIFF
--- a/client.go
+++ b/client.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"io"
+	"log"
 	"net"
 	"net/http"
 	"strconv"
@@ -182,6 +183,20 @@ func (c *Client) PushWithContext(ctx Context, n *Notification) (*Response, error
 	}
 
 	setHeaders(request, n)
+
+	log.Println("Request url:")
+	log.Println(string(url))
+
+	log.Println("Request payload:")
+	log.Println(string(payload))
+
+	log.Println("Request headers:")
+	headerJson, err := json.Marshal(request.Header)
+	if err != nil {
+		log.Println("Error marshaling header:", err)
+	} else {
+		log.Println("Header:", string(headerJson))
+	}
 
 	response, err := c.HTTPClient.Do(request)
 	if err != nil {

--- a/client.go
+++ b/client.go
@@ -9,7 +9,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"io"
-	"log"
+	"log/slog"
 	"net"
 	"net/http"
 	"strconv"
@@ -184,18 +184,20 @@ func (c *Client) PushWithContext(ctx Context, n *Notification) (*Response, error
 
 	setHeaders(request, n)
 
-	log.Println("Request url:")
-	log.Println(string(url))
+	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
+		slog.Debug("Request url:")
+		slog.Debug(string(url))
 
-	log.Println("Request payload:")
-	log.Println(string(payload))
+		slog.Debug("Request payload:")
+		slog.Debug(string(payload))
 
-	log.Println("Request headers:")
-	headerJson, err := json.Marshal(request.Header)
-	if err != nil {
-		log.Println("Error marshaling header:", err)
-	} else {
-		log.Println("Header:", string(headerJson))
+		slog.Debug("Request headers:")
+		headerJson, err := json.Marshal(request.Header)
+		if err != nil {
+			slog.Debug("Error marshaling header:", err)
+		} else {
+			slog.Debug("Header:", string(headerJson))
+		}
 	}
 
 	response, err := c.HTTPClient.Do(request)

--- a/client.go
+++ b/client.go
@@ -185,18 +185,16 @@ func (c *Client) PushWithContext(ctx Context, n *Notification) (*Response, error
 	setHeaders(request, n)
 
 	if slog.Default().Enabled(context.Background(), slog.LevelDebug) {
-		slog.Debug("Request url:")
-		slog.Debug(string(url))
+		slog.Debug("APNS request url:", string(url))
 
-		slog.Debug("Request payload:")
-		slog.Debug(string(payload))
+		slog.Debug("APNS request payload:", string(payload))
 
-		slog.Debug("Request headers:")
+		slog.Debug("APNS request headers:")
 		headerJson, err := json.Marshal(request.Header)
 		if err != nil {
-			slog.Debug("Error marshaling header:", err)
+			slog.Debug("APNS rrror marshaling header:", err)
 		} else {
-			slog.Debug("Header:", string(headerJson))
+			slog.Debug("APNS request header:", string(headerJson))
 		}
 	}
 
@@ -243,9 +241,10 @@ func setHeaders(r *http.Request, n *Notification) {
 	if n.Priority > 0 {
 		r.Header.Set("apns-priority", strconv.Itoa(n.Priority))
 	}
-	if !n.Expiration.IsZero() {
-		r.Header.Set("apns-expiration", strconv.FormatInt(n.Expiration.Unix(), 10))
-	}
+	slog.Debug("APNS not setting apns-expiration header for testing")
+	// if !n.Expiration.IsZero() {
+		// r.Header.Set("apns-expiration", strconv.FormatInt(n.Expiration.Unix(), 10))
+	//}
 	if n.PushType != "" {
 		r.Header.Set("apns-push-type", string(n.PushType))
 	} else {


### PR DESCRIPTION
### Note: This change will **NOT** be merged.
We will simply have `apns-push-service` temporarily use this branch to log the request and test for a day.
The PR is just for people to check if these code will log things correctly.