### PR TITLE
[CH-5425] Fix apns-expiration request header logic

### DIFF
--- a/client.go
+++ b/client.go
@@ -226,7 +226,7 @@ func setHeaders(r *http.Request, n *Notification) {
 	if n.Priority > 0 {
 		r.Header.Set("apns-priority", strconv.Itoa(n.Priority))
 	}
-	if !n.Expiration.IsZero() {
+	if n.Expiration.After(time.Unix(0, 0)) {
 		r.Header.Set("apns-expiration", strconv.FormatInt(n.Expiration.Unix(), 10))
 	}
 	if n.PushType != "" {

--- a/client_test.go
+++ b/client_test.go
@@ -245,6 +245,25 @@ func TestHeaders(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestExpirationHeader(t *testing.T) {
+	n := mockNotification()
+	n.ApnsID = "84DB694F-464F-49BD-960A-D6DB028335C9"
+	n.CollapseID = "game1.start.identifier"
+	n.Topic = "com.testapp"
+	n.Priority = 10
+	n.Expiration = time.Unix(0, 0)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, n.ApnsID, r.Header.Get("apns-id"))
+		assert.Equal(t, n.CollapseID, r.Header.Get("apns-collapse-id"))
+		assert.Equal(t, "10", r.Header.Get("apns-priority"))
+		assert.Equal(t, n.Topic, r.Header.Get("apns-topic"))
+		assert.Equal(t, "", r.Header.Get("apns-expiration"))
+	}))
+	defer server.Close()
+	_, err := mockClient(server.URL).Push(n)
+	assert.NoError(t, err)
+}
+
 func TestPushTypeAlertHeader(t *testing.T) {
 	n := mockNotification()
 	n.PushType = apns.PushTypeAlert


### PR DESCRIPTION
The original condition to enter the if block was `!n.Expiration.IsZero()`, this will be true if `expiration` is after 0001-01-01 00:00:00 +0000 UTC (because [Time.isZero compared with year 0001](https://pkg.go.dev/time#Time.IsZero)), but if the actual expiration time is 1970-01-01 00:00:00 +0000 UTC, the code will add a header: "apns-expiration": "0"  (or a negative number str if expiration is before 1970-01-01 00:00:00).

Adding the "apns-expiration": "0" header is unexpected behavior because according to apple:
```
If the value is nonzero, APNs stores the notification and tries to deliver it at least once, repeating the attempt as needed until the specified date. If the value is 0, APNs attempts to deliver the notification only once and doesn't store it.
```

Slack thread: https://brazetechnology.slack.com/archives/C06KHL471MM/p1710188159059929